### PR TITLE
Mr fix print percents

### DIFF
--- a/goose.go
+++ b/goose.go
@@ -32,7 +32,7 @@ func printHeader() {
 	defer file.Close()
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		fmt.Println("%v", scanner.Text())
+		fmt.Printf("%v\n", scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
 		log.Fatal(err)

--- a/goose.go
+++ b/goose.go
@@ -32,7 +32,7 @@ func printHeader() {
 	defer file.Close()
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		fmt.Println(scanner.Text())
+		fmt.Println("%v", scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
 		log.Fatal(err)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -68,6 +68,6 @@ func outputResults(result []regexfilter.Finding, interactive bool) {
 			log.Fatal(err)
 		}
 		//todo(?) : support file output target or rely on caller piping to stream?
-		fmt.Printf(string(json))
+		fmt.Printf("%v", string(json))
 	}
 }


### PR DESCRIPTION
@lapt0r This fix is is for https://github.com/lapt0r/goose/issues

Simply fixes the issue by not interpolating the string. 

The regex ```fmt.s?print(f|ln)\([^"]``` will find them all, but I don't really think it makes this to add into CI or testing. 