### PR TITLE
Implement "reflector" sieve (resolves #12)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.13
 require (
 	github.com/gogs/chardet v0.0.0-20191104214054-4b6791f73a28
 	gopkg.in/src-d/go-git.v4 v4.13.1
+	gopkg.in/vmarkovtsev/go-lcss.v1 v1.0.0-20181020221121-dfc501d07ea0
 )

--- a/internal/pkg/reflectorfilter/reflectorfilter.go
+++ b/internal/pkg/reflectorfilter/reflectorfilter.go
@@ -1,0 +1,23 @@
+package reflectorfilter
+
+import (
+	"math"
+	"regexp"
+	"strings"
+
+	"gopkg.in/vmarkovtsev/go-lcss.v1"
+)
+
+// IsReflected : Checks to see if a potential match is a partially-reflected string
+func IsReflected(potentialMatch string) bool {
+	matcher, _ := regexp.Compile("(:|:=|->|=)")
+	operator := matcher.FindString(potentialMatch)
+	if operator != "" {
+		substrings := strings.SplitN(potentialMatch, operator, 2)
+		left, right := substrings[0], substrings[1]
+		common := lcss.LongestCommonSubstring([]byte(left), []byte(right))
+		reflectorPercentage := float64(len(common)) / math.Min(float64(len(left)), float64(len(right)))
+		return reflectorPercentage > 0.7
+	}
+	return false
+}

--- a/internal/pkg/reflectorfilter/reflectorfilter_test.go
+++ b/internal/pkg/reflectorfilter/reflectorfilter_test.go
@@ -1,0 +1,30 @@
+package reflectorfilter
+
+import (
+	"testing"
+)
+
+var reflectedFinding = "password = \"password\""
+var partialReflectedFinding = "password = \"password123\""
+var nonReflectedFinding = "token = \"AKIA032as876tcbvc\""
+
+func TestIsReflectedReturnsTrueOnReflectedString(t *testing.T) {
+	result := IsReflected(reflectedFinding)
+	if !result {
+		t.Errorf("Expected result to be true but was %v for %v", result, reflectedFinding)
+	}
+}
+
+func TestIsReflectedReturnsTrueOnPartialReflectedString(t *testing.T) {
+	result := IsReflected(partialReflectedFinding)
+	if !result {
+		t.Errorf("Expected result to be true but was %v for %v", result, partialReflectedFinding)
+	}
+}
+
+func TestIsReflectedReturnsFalseOnNonReflectedString(t *testing.T) {
+	result := IsReflected(nonReflectedFinding)
+	if result {
+		t.Errorf("Expected result to be false but was %v for %v", result, nonReflectedFinding)
+	}
+}

--- a/internal/pkg/regexfilter/regexfilter.go
+++ b/internal/pkg/regexfilter/regexfilter.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lapt0r/goose/internal/pkg/configuration"
 	"github.com/lapt0r/goose/internal/pkg/loader"
+	"github.com/lapt0r/goose/internal/pkg/reflectorfilter"
 )
 
 //Finding contains the matched line, the location of the match, and the confidence of the match
@@ -54,7 +55,7 @@ func evaluateRule(line string, rule configuration.ScanRule) Finding {
 		panic(err)
 	}
 	match := matcher.FindString(line)
-	if match != "" {
+	if match != "" && reflectorfilter.IsReflected(match) == false {
 		return Finding{
 			Match:      match,
 			Location:   "NOTSET",

--- a/internal/pkg/regexfilter/regexfilter_test.go
+++ b/internal/pkg/regexfilter/regexfilter_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-var testrule = configuration.ScanRule{Name: "TestRule", Rule: "password", Confidence: 0.5, Severity: 1}
+var testrule = configuration.ScanRule{Name: "TestRule", Rule: "password = \\w{4,}", Confidence: 0.5, Severity: 1}
 var flexrule = configuration.ScanRule{Name: "Generic 8+ byte rule", Rule: "", Confidence: 0.9, Severity: 1}
 
 func TestEmptyFinding(t *testing.T) {
@@ -21,12 +21,20 @@ func TestEvaluateRuleMatch(t *testing.T) {
 	if result.IsEmpty() {
 		t.Errorf("Expected 1 result but got an empty result")
 	}
-	if result.Match != "password" {
+	if result.Match != teststring {
 		t.Errorf("Expected match to be 'password' but was '%v'", result.Match)
 	}
 	if result.Confidence != testrule.Confidence ||
 		result.Rule != testrule.Rule {
 		t.Errorf("Expected confidence 0.5 and severity 1 but found confidence %v and severity %v", result.Confidence, result.Severity)
+	}
+}
+
+func TestEvaluateRuleMatchWithReflect(t *testing.T) {
+	teststring := "password = \"password123\""
+	result := evaluateRule(teststring, testrule)
+	if !result.IsEmpty() {
+		t.Errorf("Expected no result but got 1 result")
 	}
 }
 


### PR DESCRIPTION
## Description

Add the "reflector" sieve to regex matches.  Splits match on common assignment operators, uses least common substring on the two halves of the assignment, and rejects findings with a LCS that is > 70% of the shorter of the two strings.
- Implement "reflector" module
- Unit tests for "reflector" module
- Additional unit test for regex module to ensure integration works properly
- Fix a bug in regex module exposed by "reflector" behavior.

## Link to GitHub Issue(s)
- #12 

## Checklist

- [X] Code change has test coverage for base cases
- [ ] New features are documented
- [X] No unrelated formatting changes
