### PR TITLE
add array-like secret definition (function arguments, hashmaps, arrays)

### DIFF
--- a/config/goose_rules.json
+++ b/config/goose_rules.json
@@ -6,6 +6,12 @@
         "Severity" : 1
     },
     {
+        "Name" : "Array-like 8+ byte secret",
+        "Rule" : "(?i)[{([].*(password|token|secret|key[ ,]?)(\\(\\))?\\s?[,:=]\\s?\"([a-z0-9!@#$%^&*()?,.<>;~`\\-=_]{8,})\"",
+        "Confidence" : 0.7,
+        "Severity" : 1
+    },
+    {
         "Name" : "AWS Key",
         "Rule" : "[\"']AKIA\\w+[\"']",
         "Confidence" : 0.95,


### PR DESCRIPTION
## Description

New detection rule for "array-like" secrets: arrays, hashmaps, sets, function arguments.

- New baseline Goose rule in goose_rules.json

## Link to GitHub Issue(s)
- #22 

## Checklist

- [ ] Code change has test coverage for base cases - N/A
- [ ] New features are documented - N/A
- [X] No unrelated formatting changes
