### PR TITLE
Goose Concurrency Improvements

### DIFF
--- a/goose.go
+++ b/goose.go
@@ -24,7 +24,7 @@ func main() {
 	app.Init("", *targetPath, *interactive)
 	if *interactive {
 		printHeader()
-		fmt.Printf("Initialized with %v rules.  Running..", app.RuleCount())
+		fmt.Printf("Initialized with %v rules.  Running..\n", app.RuleCount())
 	}
 
 	app.Run(*interactive)


### PR DESCRIPTION
## Description

Old Goose concurrency was mostly theatrics: wasteful multithreading for not a lot of gain.  Reversed nested loops so we serially evaluate rules and concurrently evaluate files.

- Reverse nested loop order.
- Single channel for findings
- WaitGroup blocking of goroutines
- Buffering routine to prevent deadlocking

## Link to GitHub Issue(s)

N/A

## Checklist

- [X] Code change has test coverage for base cases
- [X] New features are documented
- [X] No unrelated formatting changes
