### PR TITLE
fix EOF handing in filesystemloader

### DIFF
--- a/internal/pkg/loader/filesystemloader.go
+++ b/internal/pkg/loader/filesystemloader.go
@@ -2,6 +2,7 @@ package loader
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 
@@ -18,10 +19,17 @@ func ValidateContent(path string) bool {
 	}
 	var headerBytes = make([]byte, 1024)
 	var bytesRead, headerReadError = file.Read(headerBytes)
+
+	// empty files are valid
+	if headerReadError == io.EOF {
+		return true
+	}
+
 	if headerReadError != nil {
 		validBytes = false
 		fmt.Printf("Error reading file [%v] : %v", path, headerReadError)
 	}
+
 	//kb note: important to slice to the actual number of bytes read
 	var charSet = getByteCharset(headerBytes[0:bytesRead])
 	//kb note: should support other encodings other than ISO-8859-1

--- a/internal/pkg/loader/filesystemloader_test.go
+++ b/internal/pkg/loader/filesystemloader_test.go
@@ -39,6 +39,18 @@ func TestGetByteCharsetValidLongString(t *testing.T) {
 	}
 }
 
+func TestLoaderFileEmptyFile(t *testing.T) {
+	file, err := ioutil.TempFile("", "LoaderTestEmptyFile")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+	var testResult = ValidateContent(file.Name())
+	if !testResult {
+		t.Errorf("Expected result to be true but was %v", testResult)
+	}
+}
+
 func TestLoaderFileLongString(t *testing.T) {
 	file, err := ioutil.TempFile("", "LoaderTestFileLongString")
 	if err != nil {


### PR DESCRIPTION
## Description
`filesystemloader.ValidateContent` was not checking for end of file when
validating the file header. This meant reading an empty file would write
an error to `STDOUT`, resulting in invalid JSON in the program output.
This change adds error handling for an `EOF` error and returns true, making
the assumption that an empty file is considered valid.

## Link to GitHub Issue(s)
- https://github.com/lapt0r/goose/issues/19

## Checklist

- [x] Code change has test coverage for base cases
- [x] New features are documented
- [x] No unrelated formatting changes
